### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/antoinegreuzard/plant-care-front/security/code-scanning/4](https://github.com/antoinegreuzard/plant-care-front/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required for the tasks. Based on the operations in the workflow, the following permissions are likely needed:
- `contents: read` for accessing the repository's contents.
- `packages: read` for interacting with Docker images or other packages if necessary.
- `id-token: write` if OpenID Connect (OIDC) tokens are required for authentication.

We will add the `permissions` block at the top of the workflow file, ensuring it applies to all jobs. If any job requires additional permissions, we can override them at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
