### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/antoinegreuzard/plant-care-front/security/code-scanning/1](https://github.com/antoinegreuzard/plant-care-front/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Based on the workflow's steps, it primarily requires read access to the repository contents (`contents: read`). No write permissions are necessary, as the workflow does not modify repository contents or perform actions requiring write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
